### PR TITLE
Add slug methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,18 @@ Call your actions how you like, I prefer binding mine to props using [bindAction
 
 Actions available:
 
-| Action   | Arguments                                                                     |
-| -------- | ----------------------------------------------------------------------------- |
-| getPosts | [options (object)](https://api.ghost.org/docs/posts)                          |
-| getPost  | id (string / integer), [options (object)](https://api.ghost.org/docs/postsid) |
-| getTags  | [options (object)](https://api.ghost.org/docs/tags)                           |
-| getTag   | id (string / integer), [options (object)](https://api.ghost.org/docs/tagsid)  |
-| getUsers | [options (object)](https://api.ghost.org/docs/users)                          |
-| getUser  | id (string / integer), [options (object)](https://api.ghost.org/docs/usersid) |
-| reset    |                                                                               |
+| Action        | Arguments                                                                     |
+| ------------- | ----------------------------------------------------------------------------- |
+| getPosts      | [options (object)](https://api.ghost.org/docs/posts)                          |
+| getPost       | id (string / integer), [options (object)](https://api.ghost.org/docs/postsid) |
+| getPostBySlug | slug (string), [options (object)](https://api.ghost.org/docs/postsslugslug)   |
+| getTags       | [options (object)](https://api.ghost.org/docs/tags)                           |
+| getTag        | id (string / integer), [options (object)](https://api.ghost.org/docs/tagsid)  |
+| getTagBySlug  | slug (string), [options (object)](https://api.ghost.org/docs/tagsslugslug)    |
+| getUsers      | [options (object)](https://api.ghost.org/docs/users)                          |
+| getUser       | id (string / integer), [options (object)](https://api.ghost.org/docs/usersid) |
+| getUserBySlug | slug (string), [options (object)](https://api.ghost.org/docs/usersslugslug)   |
+| reset         |                                                                               |
 
 ## Development
 

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -15,16 +15,19 @@ const App = ({ actions, blog }) => {
       <h2>Posts</h2>
       <button onClick={() => actions.getPosts()}>Load Posts</button>
       <button onClick={() => actions.getPosts({ fields: 'title, slug' })}>Load Posts (title & slug only)</button>
-      <button onClick={() => actions.getPost(1, { include: 'author' })}>Load Single Post</button>
-      <button onClick={() => actions.getPost(1, { include: 'author' })}>Load Single Post (with author data)</button>
+      <button onClick={() => actions.getPost('1')}>Load Single Post</button>
+      <button onClick={() => actions.getPost('1', { include: 'authors' })}>Load Single Post (with author data)</button>
+      <button onClick={() => actions.getPostBySlug('my-post')}>Load Single Post by giving the slug</button>
 
       <h2>Tags</h2>
       <button onClick={() => actions.getTags()}>Load Tags</button>
       <button onClick={() => actions.getTag(1)}>Load Single Tag</button>
+      <button onClick={() => actions.getTagBySlug('my-tag')}>Load Single Tag by giving the slug</button>
 
       <h2>Users</h2>
       <button onClick={() => actions.getUsers()}>Load Users</button>
       <button onClick={() => actions.getUser(1)}>Load Single User</button>
+      <button onClick={() => actions.getUserBySlug('my-user')}>Load Single User by giving the slug</button>
 
       <h2>Reset</h2>
       <button onClick={() => actions.reset()}>Reset</button>

--- a/src/action-types.js
+++ b/src/action-types.js
@@ -1,7 +1,10 @@
 export const GET_POSTS = '@@redux-ghost/GET_POSTS';
 export const GET_POST = '@@redux-ghost/GET_POST';
+export const GET_POST_SLUG = '@@redux-ghost/GET_POST_SLUG';
 export const GET_TAGS = '@@redux-ghost/GET_TAGS';
 export const GET_TAG = '@@redux-ghost/GET_TAG';
+export const GET_TAG_SLUG = '@@redux-ghost/GET_TAG_SLUG';
 export const GET_USERS = '@@redux-ghost/GET_USERS';
 export const GET_USER = '@@redux-ghost/GET_USER';
+export const GET_USER_SLUG = '@@redux-ghost/GET_USER_SLUG';
 export const RESET = '@@redux-ghost/RESET';

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,18 @@
 import 'isomorphic-fetch';
 import { request } from './lib/api';
 import { isId } from './lib/utils';
-import { GET_POSTS, GET_POST, GET_TAGS, GET_TAG, GET_USERS, GET_USER, RESET } from './action-types';
+import {
+  GET_POSTS,
+  GET_POST,
+  GET_POST_SLUG,
+  GET_TAGS,
+  GET_TAG,
+  GET_TAG_SLUG,
+  GET_USERS,
+  GET_USER,
+  GET_USER_SLUG,
+  RESET,
+} from './action-types';
 
 const pending = (type) => ({
   type,
@@ -38,6 +49,14 @@ const getPost = (id, options) => {
   return getData(GET_POST, `/posts/${id}/`, options);
 };
 
+const getPostBySlug = (slug, options) => {
+  if (!slug) {
+    return fail(GET_POST_SLUG, 'Slug parameter is null');
+  }
+
+  return getData(GET_POST_SLUG, `/posts/slug/${slug}/`, options);
+};
+
 // Tags
 const getTags = (options) => getData(GET_TAGS, '/tags/', options);
 const getTag = (id, options) => {
@@ -46,6 +65,14 @@ const getTag = (id, options) => {
   }
 
   return getData(GET_TAG, `/tags/${id}/`, options);
+};
+
+const getTagBySlug = (slug, options) => {
+  if (!slug) {
+    return fail(GET_TAG_SLUG, 'Slug parameter is null');
+  }
+
+  return getData(GET_TAG_SLUG, `/tags/slug/${slug}/`, options);
 };
 
 // Users
@@ -58,6 +85,14 @@ const getUser = (id, options) => {
   return getData(GET_USER, `/users/${id}/`, options);
 };
 
+const getUserBySlug = (slug, options) => {
+  if (!slug) {
+    return fail(GET_USER_SLUG, 'Slug parameter is null');
+  }
+
+  return getData(GET_USER_SLUG, `/users/slug/${slug}/`, options);
+};
+
 const reset = () => ({
   type: RESET,
 });
@@ -65,9 +100,12 @@ const reset = () => ({
 export default {
   getPosts,
   getPost,
+  getPostBySlug,
   getTags,
   getTag,
+  getTagBySlug,
   getUsers,
   getUser,
+  getUserBySlug,
   reset,
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,10 +1,13 @@
 import {
   GET_POSTS,
   GET_POST,
+  GET_POST_SLUG,
   GET_TAGS,
   GET_TAG,
+  GET_TAG_SLUG,
   GET_USERS,
   GET_USER,
+  GET_USER_SLUG,
   RESET,
 } from './action-types';
 
@@ -65,10 +68,13 @@ const reducer = (state, action) => {
   const reducers = {
     [GET_POSTS]: () => updateKey('posts'),
     [GET_POST]: () => updateKey('post'),
+    [GET_POST_SLUG]: () => updateKey('post'),
     [GET_TAGS]: () => updateKey('tags'),
     [GET_TAG]: () => updateKey('tag'),
+    [GET_TAG_SLUG]: () => updateKey('tag'),
     [GET_USERS]: () => updateKey('users'),
     [GET_USER]: () => updateKey('user'),
+    [GET_USER_SLUG]: () => updateKey('user'),
     [RESET]: () => ({
       ...initialState,
     }),


### PR DESCRIPTION
I added three new methods:
- `getPostBySlug(slug)`
- `getTagBySlug(slug)`
- `getUserBySlug(slug)`

So now we can retrieve object by passing the Slug instead of Id.

If you want to improve methods name, error messages, ..., just tell me ;)